### PR TITLE
Ensure mkdir doesn't fail if .aws already exists

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,7 +72,7 @@ if [[ ! -z "$ROLE_ARN" ]]; then
   ROLE_ARN="--role-arn $ROLE_ARN"
 fi
 
-mkdir ~/.aws
+mkdir -p ~/.aws
 touch ~/.aws/credentials
 touch ~/.aws/config
 


### PR DESCRIPTION
This action was failing for me, with:

```
mkdir: cannot create directory '/github/home/.aws': File exists
```
